### PR TITLE
Marking two tests as flaky

### DIFF
--- a/tests/models/bidaf_ensemble_test.py
+++ b/tests/models/bidaf_ensemble_test.py
@@ -73,6 +73,7 @@ class BidafEnsembleTest(ModelTestCase):
             ensemble(subresults).data[0].cpu().numpy(), torch.LongTensor([2, 2]).numpy()
         )
 
+    @flaky
     def test_forward_pass_runs_correctly(self):
         """
         Check to make sure a forward pass on an ensemble of two identical copies of a model yields the same

--- a/tests/models/qanet_test.py
+++ b/tests/models/qanet_test.py
@@ -22,6 +22,7 @@ class QaNetTest(ModelTestCase):
             FIXTURES_ROOT / "qanet" / "experiment.json", FIXTURES_ROOT / "data" / "squad.json"
         )
 
+    @flaky
     def test_forward_pass_runs_correctly(self):
         batch = Batch(self.instances)
         batch.index_instances(self.vocab)


### PR DESCRIPTION
I found these two tests to be flaky. 

The `test_forward_pass_runs_correctly` test in `tests/models/bidaf_ensemble_test.py` fails about 2 out of ~50 times, whereas `test_forward_pass_runs_correctly` test in `tests/models/qanet_test.py` failed 1 out of about ~150 times.

These exhibit the same problem as PR #17. Hence, I have marked them both as flaky.

If there is a better way to fix this, I can help making those changes as well.