### PR TITLE
Update requirements.txt to use a shorter SHA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # To be changed to allennlp>=1.0 once that's released.
-git+https://github.com/allenai/allennlp.git@4e94318a7e904ce91132516eb833a06aac94222e
+git+https://github.com/allenai/allennlp.git@4e94318
 
 word2number>=1.1
 py-rouge==1.1

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open("requirements.txt") as requirements_file:
         #
         # As a mitigation, run `pip uninstall allennlp` before installing this
         # package.
-        sha = "4e94318a7e904ce91132516eb833a06aac94222e"
+        sha = "4e94318"
         requirement = f"allennlp @ git+https://github.com/allenai/allennlp@{sha}#egg=allennlp"
         install_requirements.append(requirement)
 


### PR DESCRIPTION
This is just a heads-up that shorter git commit IDs can be used with Pip, and makes it more readable.